### PR TITLE
feat: offload tracing to worker

### DIFF
--- a/src/workers/traceWorker.ts
+++ b/src/workers/traceWorker.ts
@@ -1,0 +1,44 @@
+/// <reference lib="webworker" />
+
+import * as Potrace from 'potrace';
+import type { TracingParams } from '../utils/imageProcessor';
+
+// Handle messages from main thread
+self.onmessage = async (event: MessageEvent) => {
+  const { imageData, params } = event.data as { imageData: string; params: TracingParams };
+  try {
+    // Notify that tracing is starting
+    (self as unknown as Worker).postMessage({ type: 'progress', status: 'tracing' });
+
+    const potrace = Potrace as unknown as {
+      trace: (
+        img: string,
+        opts: TracingParams,
+        cb: (err: Error | null, svg?: string) => void
+      ) => void;
+    };
+
+    const svg = await new Promise<string>((resolve, reject) => {
+      potrace.trace(imageData, params, (err: Error | null, result?: string) => {
+        if (err || !result) {
+          reject(err || new Error('Potrace returned empty SVG'));
+          return;
+        }
+        resolve(result);
+      });
+    });
+
+    // Notify that optimization step is running (for UI progress)
+    (self as unknown as Worker).postMessage({ type: 'progress', status: 'optimizing' });
+
+    // Send final result
+    (self as unknown as Worker).postMessage({ type: 'result', svg });
+  } catch (error) {
+  (self as unknown as Worker).postMessage({
+    type: 'error',
+    error: error instanceof Error ? error.message : String(error)
+  });
+  }
+};
+
+export default null as unknown as void;


### PR DESCRIPTION
## Summary
- add `traceWorker` web worker to encapsulate Potrace tracing
- refactor `processImage` to use worker with async progress updates
- drop chained timeouts in favor of async/await flow

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 12 problems, mostly in unrelated files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896ddde99748323afaf1ebcb1aa1ee7