### PR TITLE
feat: add PotraceOptions interface and typed tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,10 @@ npm run electron:build -- --linux
 ## Key Implementation Details
 
 ```typescript
+import type { PotraceOptions } from './utils/imageProcessor';
+
 // Critical configuration for Potrace tracing quality
-const potraceParams = {
+const potraceParams: PotraceOptions = {
   turdSize: 2,        // Suppress speckles (smaller = more details)
   alphaMax: 1,        // Corner threshold
   optCurve: true,     // Optimize curves

--- a/src/utils/imageProcessor.ts
+++ b/src/utils/imageProcessor.ts
@@ -7,20 +7,22 @@
 import * as Potrace from 'potrace';
 
 export type TurnPolicy = 'black' | 'white' | 'left' | 'right' | 'minority' | 'majority';
-
-export interface TracingParams {
-  turdSize: number;
-  turnPolicy: TurnPolicy;
-  alphaMax: number;
-  optCurve: boolean;
-  optTolerance: number;
-  threshold: number;
-  blackOnWhite: boolean;
-  color: string;
-  background: string;
-  invert: boolean;
-  highestQuality: boolean;
+/** Options supported by the Potrace library */
+export interface PotraceOptions {
+  turdSize?: number;
+  turnPolicy?: TurnPolicy;
+  alphaMax?: number;
+  optCurve?: boolean;
+  optTolerance?: number;
+  threshold?: number;
+  blackOnWhite?: boolean;
+  color?: string;
+  background?: string;
+  invert?: boolean;
+  highestQuality?: boolean;
 }
+
+export type TracingParams = Required<PotraceOptions>;
 
 export const DEFAULT_PARAMS: TracingParams = {
   turdSize: 2,
@@ -83,7 +85,7 @@ const createHeartbeat = (
 // Utility function to handle the TypeScript type issue with Potrace
 const trace = (
   image: string,
-  options: any,
+  options: PotraceOptions,
   callback: (err: Error | null, svg?: string) => void,
   logCallback?: (step: string, message: string, isError: boolean, timestamp: string) => void
 ) => {


### PR DESCRIPTION
## Summary
- define PotraceOptions interface for supported tracing parameters
- use PotraceOptions in trace helper and adjust TracingParams type
- document typed Potrace options in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 17 errors, 2 warnings)


------
https://chatgpt.com/codex/tasks/task_e_6896ddcc9d4c8323ac7bf11a2f1cad67