### PR TITLE
Normalize tracing colors with tinycolor2

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,11 @@ function App() {
           ...prev,
           [param]: value
         };
+      } else if (param === 'color' || param === 'background') {
+        return {
+          ...prev,
+          [param]: value
+        };
       } else {
         return {
           ...prev,

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { Settings } from 'lucide-react';
+import tinycolor from 'tinycolor2';
 import { TurnPolicy } from '../utils/imageProcessor';
 
 // Define the props interface for the component
@@ -310,17 +311,27 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                   Foreground color:
                 </label>
                 <div className="flex">
-                  <input 
-                    type="color" 
-                    id="color" 
+                  <input
+                    type="color"
+                    id="color"
                     value={color}
-                    onChange={(e) => onParamChange('color', e.target.value)}
+                    onChange={(e) => {
+                      const tc = tinycolor(e.target.value);
+                      if (tc.isValid()) {
+                        onParamChange('color', tc.toHexString());
+                      }
+                    }}
                     className="h-8 w-8 border border-gray-300 rounded mr-2"
                   />
-                  <input 
-                    type="text" 
-                    value={color} 
-                    onChange={(e) => onParamChange('color', e.target.value)}
+                  <input
+                    type="text"
+                    value={color}
+                    onChange={(e) => {
+                      const tc = tinycolor(e.target.value);
+                      if (tc.isValid()) {
+                        onParamChange('color', tc.toHexString());
+                      }
+                    }}
                     className="flex-1 border border-gray-300 rounded px-2 text-xs sm:text-sm"
                     placeholder="#000000"
                   />
@@ -332,17 +343,32 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                   Background color:
                 </label>
                 <div className="flex">
-                  <input 
-                    type="color" 
+                  <input
+                    type="color"
                     id="background"
-                    value={background === 'transparent' ? '#ffffff' : background} 
-                    onChange={(e) => onParamChange('background', e.target.value)}
+                    value={background === 'transparent' ? '#ffffff' : background}
+                    onChange={(e) => {
+                      const tc = tinycolor(e.target.value);
+                      if (tc.isValid()) {
+                        onParamChange('background', tc.toHexString());
+                      }
+                    }}
                     className="h-8 w-8 border border-gray-300 rounded mr-2"
                   />
-                  <input 
-                    type="text" 
-                    value={background} 
-                    onChange={(e) => onParamChange('background', e.target.value)}
+                  <input
+                    type="text"
+                    value={background}
+                    onChange={(e) => {
+                      const val = e.target.value.trim();
+                      if (val.toLowerCase() === 'transparent') {
+                        onParamChange('background', 'transparent');
+                      } else {
+                        const tc = tinycolor(val);
+                        if (tc.isValid()) {
+                          onParamChange('background', tc.toHexString());
+                        }
+                      }
+                    }}
                     className="flex-1 border border-gray-300 rounded px-2 text-xs sm:text-sm"
                     placeholder="transparent or #hex"
                   />


### PR DESCRIPTION
## Summary
- Validate and normalize color inputs with tinycolor2 in the settings panel
- Normalize tracing parameters to hex colors and handle transparent backgrounds
- Allow color and background strings in parameter change handler

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 18 errors, 2 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896dde73f948323ae6f32b569fb3caf