### PR TITLE
Forward maintainAspectRatio flag to resize API

### DIFF
--- a/src/components/BatchConversion.tsx
+++ b/src/components/BatchConversion.tsx
@@ -15,7 +15,12 @@ declare global {
       readDirectory: (dirPath: string) => Promise<string[] | { error: string }>;
       saveSvg: (data: { svgData: string, outputPath: string }) => Promise<{ success: boolean, path: string } | { error: string }>;
       readImageFile: (filePath: string) => Promise<string | { error: string }>;
-      resizeImage?: (data: { imageData: string, width: number, height: number }) => Promise<string | { error: string }>;
+      resizeImage?: (data: {
+        imageData: string;
+        width: number;
+        height: number;
+        maintainAspectRatio?: boolean;
+      }) => Promise<string | { error: string }>;
       toggleConsole?: () => Promise<{ visible: boolean }>;
     }
   }
@@ -335,7 +340,8 @@ const BatchConversion: React.FC<BatchConversionProps> = ({ potraceParams, onClos
           const resizedImage = await window.electronAPI.resizeImage({
             imageData: result,
             width: resizeOptions.width,
-            height: resizeOptions.height
+            height: resizeOptions.height,
+            maintainAspectRatio: resizeOptions.maintainAspectRatio
           });
           
           if (typeof resizedImage !== 'string') {


### PR DESCRIPTION
## Summary
- extend the electron resizeImage typing to accept a maintainAspectRatio flag
- forward the current maintainAspectRatio setting when resizing batch conversion images

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*
- npm run electron:dev *(fails: electron binary missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e417bf35b083238a408485589c3370